### PR TITLE
HP-1581 fix 'Indirect modification of overloaded property hipanel\modules\ipam\models\Address::$links has no effect' Notice on ipam/address/index page

### DIFF
--- a/src/models/Address.php
+++ b/src/models/Address.php
@@ -8,10 +8,13 @@ use hipanel\modules\ipam\models\query\AddressQuery;
 use hipanel\modules\ipam\models\traits\IPBlockTrait;
 use hiqdev\hiart\ActiveQuery;
 use Yii;
-use yii\db\QueryInterface;
-use yii\helpers\ArrayHelper;
 use yii\web\JsExpression;
 
+/**
+ * @property Link[] $links
+ * @property string $device
+ * @property int $device_id
+ */
 class Address extends Prefix
 {
     use IPBlockTrait, ModelTrait;
@@ -61,12 +64,27 @@ class Address extends Prefix
     public function afterFind()
     {
         parent::afterFind();
-        if ($this->isRelationPopulated('links')) {
-            $link = reset($this->links);
-            if ($link instanceof Link) {
+
+        if ($this->hasAnyLinks()) {
+            $link = $this->getFirstLink();
+
+            if ($link) {
                 $this->device = $link->device;
                 $this->device_id = $link->device_id;
             }
         }
+    }
+
+    private function hasAnyLinks(): bool
+    {
+        return $this->isRelationPopulated('links') && !empty($this->links);
+    }
+
+    private function getFirstLink(): ?Link
+    {
+        $links = $this->links;
+        $link = reset($links);
+
+        return $link instanceof Link ? $link : null;
     }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/82b0aa4e-e54c-4270-8ef7-7d9b866e6109)
https://sentry.hiqdev.com/organizations/hiqdev/issues/26898

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling for device information by encapsulating link-checking logic, resulting in more maintainable code.
- **Documentation**
  - Enhanced class documentation to clarify available properties related to device and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->