### PR TITLE
HP-1581 fix 'Attempt to read property "role" on null' Warning on ipam/prefix/get-tree-grid-rows page

### DIFF
--- a/src/grid/PrefixGridView.php
+++ b/src/grid/PrefixGridView.php
@@ -34,9 +34,9 @@ class PrefixGridView extends BoxedGridView
                         return Html::a($ip, [
                             '@prefix/create',
                             'ip' => $ip,
-                            'vrf' => Html::encode($this->parent->vrf),
-                            'role' => Html::encode($this->parent->role),
-                            'site' => Html::encode($this->parent->site),
+                            'vrf' => $this->parent ? Html::encode($this->parent->vrf) : '',
+                            'role' => $this->parent ? Html::encode($this->parent->role) : '',
+                            'site' => $this->parent ? Html::encode($this->parent->site) : '',
                         ], ['class' => 'text-bold']);
                     }
                     $ip = Html::a($ip, ['@prefix/view', 'id' => $prefix->id], ['class' => 'text-bold']);

--- a/src/models/Prefix.php
+++ b/src/models/Prefix.php
@@ -12,11 +12,13 @@ use yii\db\Query;
 use yii\db\QueryInterface;
 
 /**
- * @property string ip
- * @property string vrf
- * @property Prefix|null parent
- * @property string type
- * @property int id
+ * @property string $ip
+ * @property string $vrf
+ * @property Prefix|null $parent
+ * @property string $type
+ * @property int $id
+ * @property string $role
+ * @property string $site
  */
 class Prefix extends Model
 {

--- a/src/models/Prefix.php
+++ b/src/models/Prefix.php
@@ -19,6 +19,8 @@ use yii\db\QueryInterface;
  * @property int $id
  * @property string $role
  * @property string $site
+ * @property string $state
+ * @property string $client
  */
 class Prefix extends Model
 {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3382edca-8540-4de9-a06a-01ebc737d442)
https://sentry.hiqdev.com/organizations/hiqdev/issues/27340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when generating links for suggested prefix IPs by adding safeguards against missing parent data.

- **Documentation**
  - Updated internal documentation to clarify and standardize property annotations for prefix-related information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->